### PR TITLE
feat: add support for 'defaultRichTextElements' in IntlProvider

### DIFF
--- a/src/withReactIntl.tsx
+++ b/src/withReactIntl.tsx
@@ -18,7 +18,7 @@ export const withReactIntl = (
     const currentLocale = locale || defaultLocale;
 
     if (currentLocale && reactIntl) {
-        const {formats, messages} = reactIntl;
+        const {formats, messages, defaultRichTextElements} = reactIntl;
         const safeFormats = formats ? formats[currentLocale] : undefined;
         if (messages) {
             return (
@@ -28,6 +28,7 @@ export const withReactIntl = (
                     messages={messages[currentLocale]}
                     locale={currentLocale}
                     defaultLocale={defaultLocale}
+                    defaultRichTextElements={defaultRichTextElements}
                 >
                     <>{story(context)}</>
                 </IntlProvider>


### PR DESCRIPTION
### Summary
Add 'defaultRichTextElements' support in the `IntlProvider` component, enhancing compatibility with the `react-intl` library for improved rich text handling in internationalization.

https://formatjs.io/docs/react-intl/components/#intlprovider

### Context

We can use rich text elements for individual <FormattedMessage /> components. 
 
```
<FormattedMessage
          values={{
            p: (...chunks) => <p>{chunks}</p>,
            lineBreak: <br />
          }}
/>
```

But `react-intl` also supports defaultRichTextElements prop, which helps us to define them globally.

```
 <IntlProvider
        locale={lang}
        messages={messages}
        textComponent="span"
        defaultRichTextElements={{
          lineBreak: <br />,
        }}
      >
```

Here is an example string:

`"I want to give a line break here. {lineBreak}Then, I can continue from the next line."`

From:
<img width="597" alt="image" src="https://github.com/stevensacks/storybook-react-intl/assets/22245039/3c5670a2-8852-4a8d-95cc-c806c1e71546">

To:
<img width="597" alt="image" src="https://github.com/stevensacks/storybook-react-intl/assets/22245039/2c34a95f-b4f5-4e8d-a6e4-6f89e4b049bb">

### Usage
`reactIntl.ts(x)`

```
export const reactIntl = {
  defaultLocale: 'en',
  locales,
  messages,
  formats,
  defaultRichTextElements: {
    lineBreak: <br />,
  },
};
```