### PR TITLE
fix: Remove React from the Bundle

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -91,7 +91,7 @@ export default defineConfig(async (options) => {
       format: ["esm"],
       target: BROWSER_TARGET,
       platform: "browser",
-      external: globalPreviewPackages,
+      external: [...globalPreviewPackages, "react"],
     });
   }
 


### PR DESCRIPTION
This fixes issues using this library with React 19 and Storybook 8.4.
A similar issue is seen in the `storybook-next-intl` library at: https://github.com/stevensacks/storybook-next-intl/issues/5 
The fix for the above issue in that library has been used as the basis for this fix also.

React is imported by `withReactIntl.tsx` and included in the tsup bundle. Exclude it from the bundle to use the version from the consuming project.

Testing

- `npm run build` and verified react is not included in `dist/preview.js`
- `npm run storybook` and verified the addon work as expected